### PR TITLE
First cut at using testers2 parallel updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Scala template
+*.class
+*.log
+### SBT template
+# Simple Build Tool
+# http://www.scala-sbt.org/release/docs/Getting-Started/Directories.html#configuring-version-control
+
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+.history
+.cache
+.lib/
+
+.idea/
+out/
+test_run_dir/

--- a/build.sbt
+++ b/build.sbt
@@ -19,11 +19,12 @@ val defaultVersions = Map(
   "firrtl" -> "1.2-SNAPSHOT",
   "chisel3" -> "3.2-SNAPSHOT",
   "treadle" -> "1.1-SNAPSHOT",
-  "chisel-iotesters" -> "1.3-SNAPSHOT"
+  "chisel-iotesters" -> "1.3-SNAPSHOT",
+  "chisel-testers2"  -> "0.1-SNAPSHOT"
   )
 
 
-libraryDependencies ++= Seq("firrtl","chisel3", "treadle", "chisel-iotesters").map {
+libraryDependencies ++= Seq("firrtl", "chisel3", "treadle", "chisel-iotesters", "chisel-testers2").map {
   dep: String => org %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) }
 
 // Linear aglebra 

--- a/src/test/scala/unit/GridTestUsingTesters2.scala
+++ b/src/test/scala/unit/GridTestUsingTesters2.scala
@@ -1,0 +1,89 @@
+// See README.md for license details.
+
+package unit
+
+import Cfg.{xlen, ylen}
+import chisel3._
+import chisel3.iotesters.TesterOptionsManager
+import chisel3.tester._
+import org.la4j.matrix.DenseMatrix
+import org.scalatest.FreeSpec
+import tpu_pkg.GridShell
+
+import scala.util.Random
+
+class GridTestUsingTesters2 extends FreeSpec with ChiselScalatestTester {
+  "parallel events should work" in {
+    val manager = new TesterOptionsManager {
+      testerOptions = testerOptions.copy(generateVcdOutput = "on")
+      treadleOptions = treadleOptions.copy(writeVCD = true)
+    }
+    (new TestBuilder(() => new GridShell, Some(manager), None)) { dut =>
+      val uut = dut.io
+
+      // Gen input data
+      val seed  = 0
+      val r = new java.util.Random(seed)
+
+      //val A,B,C,D  = DenseMatrix.random(xlen, ylen, r)
+      val A,B,C,D  = DenseMatrix.zero(xlen, ylen)
+
+      val MaxVal  = 8
+
+
+      for {
+        i <- 0 until xlen
+        j <- 0 until ylen
+      } yield {
+        A.set(i,j, r.nextInt(MaxVal))
+        B.set(i,j, r.nextInt(MaxVal))
+        C.set(i,j, r.nextInt(MaxVal))
+        D.set(i,j, r.nextInt(MaxVal))
+      }
+
+      def driveA (): Unit = {
+
+        for {
+          i <- 0 until xlen
+          j <- 0 until ylen
+        } yield {
+          uut.adin(0).valid.poke(true.B)
+          uut.adin(0).bits.data.poke( A.get(i,j).toInt.U)
+          dut.clock.step(1)
+        }
+        uut.adin(0).valid.poke(true.B)
+        uut.adin(0).bits.data.poke(0.U)
+
+      }
+
+      def driveB (): Unit = {
+
+        for {
+          i <- 0 until xlen
+          j <- 0 until ylen
+        } yield {
+          uut.adin(1).valid.poke(true.B)
+          uut.adin(1).bits.data.poke( B.get(i,j).toInt.U)
+          dut.clock.step(1)
+        }
+        uut.adin(1).valid.poke(true.B)
+        uut.adin(1).bits.data.poke(0.U)
+      }
+
+      def runpar0(): Unit = {
+        fork {
+          driveA()
+        }.fork {
+          driveB()
+        }.join
+      }
+
+      dut.clock.step(5)
+
+      timescope {
+        runpar0()
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
For reference I have provided an adaptation of my earlier testers2 example.
I believe the testers2 approach gets around a rather difficult aspect of using ZIO
I still think the step() methods called at GridTest:46 and GridTest:61 will always be viewed
as a separate unrelated calls to advance the clock. This is not a fault of ZIO, but rather the way the backend interface works. Testers2 has done a lot of work to handle this problem of advancement of the clock when different threads are accessing the DUT. 
I did not understand the subtleties of runpar0, runpar1, and runpar2, and what they were supposed to be demonstrating. If you let me know what that is I can try and add those to this implementation.